### PR TITLE
ExactSizeIterator and FusedIterator for IntoIter

### DIFF
--- a/src/rbmap.rs
+++ b/src/rbmap.rs
@@ -671,6 +671,33 @@ impl<K: PartialOrd, V> Iterator for IntoIter<K, V> {
     }
 }
 
+/// Provides the trait ExactSizeIterator for IntoIter<K, V>
+/// # Example:
+/// ```
+/// use rb_tree::RBMap;
+/// use std::iter::FusedIterator;
+///
+/// let mut map = RBMap::new();
+///
+/// map.insert(5, "Is");
+/// map.insert(2, "This");
+/// map.insert(7, "The");
+/// map.insert(6, "Real");
+/// map.insert(6, "World");
+///
+/// let mut iterator = map.into_iter();
+/// assert_eq!(iterator.len(), 4);
+/// let _ = iterator.next();
+/// assert_eq!(iterator.len(), 3);
+/// ```
+impl<K: PartialOrd, V> ExactSizeIterator for IntoIter<K, V>  {
+    fn len(&self) -> usize {
+        self.tree.len()
+    }
+}
+
+impl<K: PartialOrd, V> FusedIterator for IntoIter<K, V> {}
+
 impl<K: PartialOrd, V> IntoIterator for RBMap<K, V> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;

--- a/src/rbqueue.rs
+++ b/src/rbqueue.rs
@@ -515,13 +515,13 @@ impl<T> Iterator for IntoIter<T> {
 /// let _ = iterator.next();
 /// assert_eq!(iterator.len(), 2);
 /// ```
-impl<T: PartialOrd> ExactSizeIterator for IntoIter<T>  {
+impl<T> ExactSizeIterator for IntoIter<T>  {
     fn len(&self) -> usize {
         self.order.len()
     }
 }
 
-impl<T: PartialOrd> FusedIterator for IntoIter<T> {}
+impl<T> FusedIterator for IntoIter<T> {}
 
 impl<T, P> IntoIterator for RBQueue<T, P>
 where P: Copy + Fn(&T, &T) -> std::cmp::Ordering {

--- a/src/rbqueue.rs
+++ b/src/rbqueue.rs
@@ -500,6 +500,29 @@ impl<T> Iterator for IntoIter<T> {
     }
 }
 
+/// Provides the trait ExactSizeIterator for IntoIter<T>
+/// # Example:
+/// ```
+/// use rb_tree::RBQueue;
+///
+/// let mut t = RBQueue::<i8, _>::new(|l, r| l.partial_cmp(r).unwrap());
+/// t.insert(2);
+/// t.insert(1);
+/// t.insert(3);
+///
+/// let mut iterator = t.into_iter();
+/// assert_eq!(iterator.len(), 3);
+/// let _ = iterator.next();
+/// assert_eq!(iterator.len(), 2);
+/// ```
+impl<T: PartialOrd> ExactSizeIterator for IntoIter<T>  {
+    fn len(&self) -> usize {
+        self.order.len()
+    }
+}
+
+impl<T: PartialOrd> FusedIterator for IntoIter<T> {}
+
 impl<T, P> IntoIterator for RBQueue<T, P>
 where P: Copy + Fn(&T, &T) -> std::cmp::Ordering {
     type Item = T;

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -628,6 +628,29 @@ impl<T: PartialOrd> Iterator for IntoIter<T> {
     }
 }
 
+/// Provides the trait ExactSizeIterator for IntoIter<T>
+/// # Example:
+/// ```
+/// use rb_tree::RBTree;
+///
+/// let mut t = RBTree::new();
+/// t.insert(3);
+/// t.insert(1);
+/// t.insert(5);
+///
+/// let mut iterator = t.into_iter();
+/// assert_eq!(iterator.len(), 3);
+/// let _ = iterator.next();
+/// assert_eq!(iterator.len(), 2);
+/// ```
+impl<T: PartialOrd> ExactSizeIterator for IntoIter<T>  {
+    fn len(&self) -> usize {
+        self.tree.len()
+    }
+}
+
+impl<T: PartialOrd> FusedIterator for IntoIter<T> {}
+
 impl<T: PartialOrd> IntoIterator for RBTree<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;


### PR DESCRIPTION
I needed the ExactSizeIterator trait for RBMap for a test.
Since the three IntoIter structs are quite similar I could implement it for all of them.

Sadly my test didn't work out the way I needed it to, so there is no rush with this PR.
If you do decide to merge this I would suggest that you take a look at the clippy issues before publishing.