### PR TITLE
Implement std::iter::Extend for RBTree, RBMap and RBQueue

### DIFF
--- a/src/rbmap.rs
+++ b/src/rbmap.rs
@@ -846,6 +846,22 @@ impl<K: PartialOrd, V> FromIterator<(K, V)> for RBMap<K, V> {
     }
 }
 
+impl<K: PartialOrd, V> Extend<(K, V)> for RBMap<K, V> {
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        for (key, val) in iter {
+            self.insert(key, val);
+        }
+    }
+}
+
+impl<'a, K: PartialOrd + Copy + 'a, V: Copy + 'a> Extend<(&'a K, &'a V)> for RBMap<K, V> {
+    fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
+        for (&key, &val) in iter {
+            self.insert(key, val);
+        }
+    }
+}
+
 // this should be fine to do since only one
 // borrow can occur when mutable
 pub struct Iter<'a, K: PartialOrd, V> {

--- a/src/rbqueue.rs
+++ b/src/rbqueue.rs
@@ -497,6 +497,29 @@ where P: Copy + Fn(&T, &T) -> std::cmp::Ordering {
     }
 }
 
+impl<T, P> Extend<T> for RBQueue<T, P>
+where
+    P: Copy + Fn(&T, &T) -> std::cmp::Ordering,
+{
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for i in iter {
+            self.insert(i);
+        }
+    }
+}
+
+impl<'a, T, P> Extend<&'a T> for RBQueue<T, P>
+where
+    T: Copy + 'a,
+    P: Copy + Fn(&T, &T) -> std::cmp::Ordering,
+{
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        for &i in iter {
+            self.insert(i);
+        }
+    }
+}
+
 pub struct Drain<T> {
     ordered: Vec<T>
 }

--- a/src/rbtree.rs
+++ b/src/rbtree.rs
@@ -681,6 +681,22 @@ impl<T: PartialOrd> FromIterator<T> for RBTree<T> {
     }
 }
 
+impl<T: PartialOrd> Extend<T> for RBTree<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for i in iter {
+            self.insert(i);
+        }
+    }
+}
+
+impl<'a, T: PartialOrd + Copy + 'a> Extend<&'a T> for RBTree<T> {
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        for &i in iter {
+            self.insert(i);
+        }
+    }
+}
+
 pub struct Drain<T: PartialOrd> {
     tree: RBTree<T>
 }

--- a/src/rbtree_tests.rs
+++ b/src/rbtree_tests.rs
@@ -962,14 +962,31 @@ fn test_iterator() {
     t.insert(34);
     t.insert(1);
 
-    let expected = [
-        0, 1, 2, 4,
-        5, 7, 13, 14,
-        15, 21, 23, 26,
-        34, 37, 41
-    ];
+    let expected = [0, 1, 2, 4, 5, 7, 13, 14, 15, 21, 23, 26, 34, 37, 41];
+    let mut len = 0;
 
-    for (i, v) in t.iter().enumerate() {
-        assert_eq!(v, &expected[i]);
+    for (expected, v) in t.iter().zip(&expected) {
+        assert_eq!(v, expected);
+        len += 1;
     }
+
+    assert_eq!(len, expected.len());
+}
+
+#[test]
+fn test_extend() {
+    let mut t = RBTree::new();
+    t.extend(vec![90, 120, 12]);
+    t.extend(std::iter::once(34).chain((809..=811).rev()));
+    t.extend(5..8);
+
+    let expected = [5, 6, 7, 12, 34, 90, 120, 809, 810, 811];
+    let mut len = 0;
+
+    for (expected, v) in t.iter().zip(&expected) {
+        assert_eq!(v, expected);
+        len += 1;
+    }
+
+    assert_eq!(len, expected.len());
 }


### PR DESCRIPTION
Implementing [`std::iter::Extend`](https://doc.rust-lang.org/std/iter/trait.Extend.html) makes the collections more convenient to use. I just noticed the implementations were missing when I was using your library. If you are wondering why I also added implementations for `&'a T` for any types `T` implementing `Copy` (and `Sized`), I simply mirrored what the standard library is doing (e.g. see [here](https://doc.rust-lang.org/std/iter/trait.Extend.html#impl-Extend%3C(%26%27a%20K%2C%20%26%27a%20V)%3E-1), [here](https://doc.rust-lang.org/std/iter/trait.Extend.html#impl-Extend%3C%26%27a%20T%3E-4) or [here](https://doc.rust-lang.org/std/iter/trait.Extend.html#impl-Extend%3C%26%27a%20T%3E-5)).

I added (only) one extra test but I guess it should suffice. I had to modify `test_iterator` to also check the length of the iterated red-black tree since before my change, it could've gone unnoticed if the iterator yielded too few elements.

As an aside, I noticed that your project does not use `rustfmt` or at least not the latest version of it. I highly recommend integrating it into your workflow to make the life of contributors easier: My local setup auto-formats on save and therefore I had to use `git add -p` to manually undo the formatting to be able to submit a minimal patch. I am pretty certain that the majority of library writers uses `rustfmt`.

Anyway, thanks for writing this library! Greatly appreciated.