### PR TITLE
Added map and queue benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,12 @@ map = ["set"]
 fnv = "^1.0.7"
 rand = "0.8.3"
 rand_chacha = "0.3.0"
+criterion = "^0.3.4"
+
+[[bench]]
+name = "map_bench"
+harness = false
+
+[[bench]]
+name = "queue_bench"
+harness = false

--- a/benches/map_bench.rs
+++ b/benches/map_bench.rs
@@ -1,0 +1,74 @@
+extern crate rand;
+extern crate rand_chacha;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use fnv::FnvHashSet;
+use rand::{Rng, SeedableRng};
+use rb_tree::RBMap;
+
+const SIZE: usize = 5000;
+
+/// Bench test adding 'random' numbers (same sequence every time)
+/// and then removing them in the reverse order of insertion.
+#[cfg(feature = "map")]
+#[cfg(test)]
+fn map_random(c: &mut Criterion) {
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+    let mut picked_values = FnvHashSet::<usize>::default();
+
+    let mut values = Vec::<usize>::with_capacity(SIZE);
+
+    while values.len() < SIZE {
+        let value = rng.gen_range(0_..(SIZE * 2));
+        if picked_values.contains(&value) {
+            continue;
+        } else {
+            picked_values.insert(value);
+            values.push(value);
+        }
+    }
+    drop(picked_values);
+    // wonder why to_owned() doesn't work here
+    let values_reverse: Vec<usize> = values.iter().rev().map(|x| *x).collect();
+
+    c.bench_function("map_random", |b| {
+        b.iter({
+            || {
+                let mut q = RBMap::<usize, usize>::new();
+                for v in values.iter() {
+                    q.insert(*v, v + 1);
+                }
+                for v in values_reverse.iter() {
+                    q.remove(v);
+                }
+            }
+        })
+    });
+}
+
+/// Bench test adding numbers in sorted order
+/// and then removing them in the reverse order of insertion.
+#[cfg(feature = "map")]
+#[cfg(test)]
+fn map_in_order(c: &mut Criterion) {
+    c.bench_function("map_in_order", |b| {
+        b.iter({
+            || {
+                let mut q = RBMap::<usize, usize>::new();
+                for v in 0..=SIZE {
+                    q.insert(v, v + 1);
+                }
+                for v in SIZE..0 {
+                    let _ = q.remove(&v);
+                }
+            }
+        })
+    });
+}
+
+#[cfg(feature = "map")]
+criterion_group!(map_benches, map_in_order, map_random);
+#[cfg(feature = "map")]
+criterion_main!(map_benches);

--- a/benches/queue_bench.rs
+++ b/benches/queue_bench.rs
@@ -1,0 +1,70 @@
+extern crate rand;
+extern crate rand_chacha;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use fnv::FnvHashSet;
+use rand::{Rng, SeedableRng};
+use rb_tree::RBQueue;
+
+const SIZE: usize = 5000;
+
+/// Bench test adding 'random' numbers (same sequence every time)
+/// and then popping them all.
+#[cfg(feature = "queue")]
+#[cfg(test)]
+fn queue_random(c: &mut Criterion) {
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+    let mut picked_values = FnvHashSet::<usize>::default();
+    let mut values = Vec::<usize>::with_capacity(SIZE);
+
+    while values.len() < SIZE {
+        let value = rng.gen_range(0_..(SIZE * 2));
+        if picked_values.contains(&value) {
+            continue;
+        } else {
+            picked_values.insert(value);
+            values.push(value);
+        }
+    }
+    drop(picked_values);
+
+    c.bench_function("queue_random", |b| {
+        b.iter({
+            || {
+                let mut q = RBQueue::new(|l: &usize, r| l.cmp(r));
+                for v in values.iter() {
+                    q.insert(*v);
+                }
+                while !q.is_empty() {
+                    let _ = q.pop();
+                }
+            }
+        })
+    });
+}
+
+/// Bench test adding numbers in sorted order and then popping them all.
+#[cfg(feature = "queue")]
+#[cfg(test)]
+fn queue_in_order(c: &mut Criterion) {
+    c.bench_function("queue_in_order", |b| {
+        b.iter({
+            || {
+                let mut q = RBQueue::new(|l: &usize, r| l.cmp(r));
+                for v in 0..=SIZE {
+                    q.insert(v);
+                }
+                while !q.is_empty() {
+                    let _ = q.pop();
+                }
+            }
+        })
+    });
+}
+
+#[cfg(feature = "queue")]
+criterion_group!(queue_benches, queue_in_order, queue_random);
+#[cfg(feature = "queue")]
+criterion_main!(queue_benches);


### PR DESCRIPTION
As mentioned in #13

I figured that It would be enough with bench tests for rb_map and rb_queue since rb_map is implemented in terms of a rb_tree. 

Run the tests with 'cargo bench'

